### PR TITLE
Unsafe cast generates incorrect code for g++

### DIFF
--- a/src/hx/widgets/Button.hx
+++ b/src/hx/widgets/Button.hx
@@ -12,7 +12,7 @@ class Button extends Window {
         
         var buttonRef:WxButtonRef = WxButtonRef.createInstance();
         buttonRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, label);
-        _ref = cast buttonRef;
+        untyped __cpp__("_ref = *buttonRef");
     }
     
     public function setBitmap(bitmap:Bitmap) {

--- a/src/hx/widgets/CheckBox.hx
+++ b/src/hx/widgets/CheckBox.hx
@@ -10,7 +10,7 @@ class CheckBox extends Window {
         
         var checkboxRef:WxCheckBoxRef = WxCheckBoxRef.createInstance();
         checkboxRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, label);
-        _ref = cast checkboxRef;
+        untyped __cpp__("_ref = *checkboxRef");
     }
     
     public var value(get, set):Bool;

--- a/src/hx/widgets/Frame.hx
+++ b/src/hx/widgets/Frame.hx
@@ -12,7 +12,7 @@ class Frame extends Window {
         
         var frameRef:WxFrameRef = WxFrameRef.createInstance();
         frameRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, title);
-        _ref = cast frameRef;
+        untyped __cpp__("_ref = *frameRef");
     }
     
     public function createStatusBar() {

--- a/src/hx/widgets/Gauge.hx
+++ b/src/hx/widgets/Gauge.hx
@@ -8,9 +8,9 @@ class Gauge extends Window {
     public function new(parent:Window, range:Int = 100, id:Int = -1) {
         super(parent, id);
         
-        var guageRef:WxGaugeRef = WxGaugeRef.createInstance();
-        guageRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, range);
-        _ref = cast guageRef;
+        var gaugeRef:WxGaugeRef = WxGaugeRef.createInstance();
+        gaugeRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, range);
+        untyped __cpp__("_ref = *gaugeRef");
     }
     
     public var value(get, set):Int;

--- a/src/hx/widgets/HyperlinkCtrl.hx
+++ b/src/hx/widgets/HyperlinkCtrl.hx
@@ -21,7 +21,7 @@ class HyperlinkCtrl extends Window {
         
         var linkRef:WxHyperlinkCtrlRef = WxHyperlinkCtrlRef.createInstance();
         linkRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, text, url, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast linkRef;
+        untyped __cpp__("_ref = *linkRef");
     }
 }
 

--- a/src/hx/widgets/Notebook.hx
+++ b/src/hx/widgets/Notebook.hx
@@ -12,7 +12,7 @@ class Notebook extends Window {
         
         var notebookRef:WxNotebookRef = WxNotebookRef.createInstance();
         notebookRef.create(parent != null ? parent._ref : Window.nullWindowRef, id);
-        _ref = cast notebookRef;
+        untyped __cpp__("_ref = *notebookRef");
     }
     
     public function addPage(page:Window, text:String, select:Bool = false, imageId:Int = -1):Bool {

--- a/src/hx/widgets/Panel.hx
+++ b/src/hx/widgets/Panel.hx
@@ -12,7 +12,7 @@ class Panel extends Window {
         
         var panelRef:WxPanelRef = WxPanelRef.createInstance();
         panelRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast panelRef;
+        untyped __cpp__("_ref = *panelRef");
     }
 }
 

--- a/src/hx/widgets/RadioButton.hx
+++ b/src/hx/widgets/RadioButton.hx
@@ -18,7 +18,7 @@ class RadioButton extends Window {
         
         var radioRef:WxRadioButtonRef = WxRadioButtonRef.createInstance();
         radioRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, title, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast radioRef;
+        untyped __cpp__("_ref = *radioRef");
     }
     
     public var value(get, set):Bool;

--- a/src/hx/widgets/ScrolledWindow.hx
+++ b/src/hx/widgets/ScrolledWindow.hx
@@ -12,7 +12,7 @@ class ScrolledWindow extends Window {
         
         var scrolledWindowRef:WxScrolledWindowRef = WxScrolledWindowRef.createInstance();
         scrolledWindowRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast scrolledWindowRef;
+        untyped __cpp__("_ref = *scrolledWindowRef");
     }
     
     public function setScrollbars(pixelsPerUnitX:Int, pixelsPerUnitY:Int, noUnitsX:Int, noUnitsY:Int) {

--- a/src/hx/widgets/Slider.hx
+++ b/src/hx/widgets/Slider.hx
@@ -34,7 +34,7 @@ class Slider extends Window {
         
         var sliderRef:WxSliderRef = WxSliderRef.createInstance();
         sliderRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, value, min, max, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast sliderRef;
+        untyped __cpp__("_ref = *sliderRef");
     }
     
     public var value(get, set):Int;

--- a/src/hx/widgets/StaticBitmap.hx
+++ b/src/hx/widgets/StaticBitmap.hx
@@ -12,7 +12,7 @@ class StaticBitmap extends Window {
         
         var bitmapRef:WxStaticBitmapRef = WxStaticBitmapRef.createInstance();
         bitmapRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, bitmap._ref);
-        _ref = cast bitmapRef;
+        untyped __cpp__("_ref = *bitmapRef");
     }
 }
 

--- a/src/hx/widgets/StaticBox.hx
+++ b/src/hx/widgets/StaticBox.hx
@@ -10,7 +10,7 @@ class StaticBox extends Window {
         
         var boxRef:WxStaticBoxRef = WxStaticBoxRef.createInstance();
         boxRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, title);
-        _ref = cast boxRef;
+        untyped __cpp__("_ref = *boxRef");
     }
 }
 

--- a/src/hx/widgets/StaticText.hx
+++ b/src/hx/widgets/StaticText.hx
@@ -23,7 +23,7 @@ class StaticText extends Window {
         
         var textRef:WxStaticTextRef = WxStaticTextRef.createInstance();
         textRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, text, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast textRef;
+        untyped __cpp__("_ref = *textRef");
     }
     
 }

--- a/src/hx/widgets/TextCtrl.hx
+++ b/src/hx/widgets/TextCtrl.hx
@@ -35,7 +35,7 @@ class TextCtrl extends Window {
         
         var textRef:WxTextCtrlRef = WxTextCtrlRef.createInstance();
         textRef.create(parent != null ? parent._ref : Window.nullWindowRef, id, text, Point.defaultPositionRef, Size.defaultSizeRef, style);
-        _ref = cast textRef;
+        untyped __cpp__("_ref = *textRef");
     }
     
     public function appendText(value:String) {


### PR DESCRIPTION
This change allows g++ to compile and run
(but without Bitmap.fromHaxeResource which segfault).

Note: several components aren't working as expected. 