### PR TITLE
Add haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,22 @@
+{
+	"name": "hxWidgets",
+	"license": "MIT",
+	"tags": [
+		"ui",
+		"gui",
+		"native",
+		"hxcpp",
+		"wxWidgets"
+	],
+	"description": "Haxe externs (and wrappers) for wxWidgets",
+	"contributors": [
+		"ianharrigan"
+	],
+	"releasenote": "Now building on windows, linux and mac",
+	"version": "0.0.1",
+	"classPath": "src",
+	"url": "https://github.com/ianharrigan/hxWidgets",
+	"dependencies": {
+		"hxcpp": ""
+	}
+}

--- a/samples/00-Showcase/build.hxml
+++ b/samples/00-Showcase/build.hxml
@@ -4,7 +4,7 @@
 -resource assets/img/inbox--arrow.bmp@inbox--arrow.bmp
 -resource assets/img/inbox-document.bmp@inbox-document.bmp
 
--cp ../../src/
+-lib hxWidgets
 -cp src/
 -main Main
 -cpp bin


### PR DESCRIPTION
The presence of the classpath in haxelib.json changes the value of `${haxelib:hxWidgets}` to include src, so all the `../` need to stay.

Wasn't sure what to put in license, but since MIT is the closest to the wxWidgets license (a modified lgpl which allows static linking).