### PR TITLE
Implemented children accessors and other useful functions

### DIFF
--- a/Build.xml
+++ b/Build.xml
@@ -24,15 +24,15 @@
 		</files>
 
 		<target id="haxe" tool="linker" toolid="exe">
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_xrc.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_webview.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_html.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_qa.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_adv.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_core.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxbase30u_xml.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxbase30u_net.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxbase30u.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_xrc.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_webview.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_html.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_qa.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_adv.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_core.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxbase30u_xml.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxbase30u_net.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxbase30u.lib" />
 		</target>
 	</section>
 

--- a/Build.xml
+++ b/Build.xml
@@ -24,15 +24,15 @@
 		</files>
 
 		<target id="haxe" tool="linker" toolid="exe">
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_xrc.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_webview.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_html.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_qa.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_adv.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxmsw30u_core.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxbase30u_xml.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxbase30u_net.lib" />
-			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/vc120/${MACHINE}/lib/wxbase30u.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_xrc.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_webview.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_html.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_qa.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_adv.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxmsw30u_core.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxbase30u_xml.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxbase30u_net.lib" />
+			<lib name="${haxelib:hxWidgets}/../wxWidgets/windows/${vc}/${MACHINE}/lib/wxbase30u.lib" />
 		</target>
 	</section>
 

--- a/samples/00-Showcase/src/Main.hx
+++ b/samples/00-Showcase/src/Main.hx
@@ -242,6 +242,8 @@ class Main {
                     button.setSize(5, 5, 100, 30);
                 tabs.addPage(panel3, "Tab 3", false, 2);
                 
+        trace('Number of children in frame:' + frame.getChildren().length);
+                
         app.run();
         app.exit();
     }

--- a/src/hx/widgets/StaticText.hx
+++ b/src/hx/widgets/StaticText.hx
@@ -26,6 +26,17 @@ class StaticText extends Window {
         _ref = cast textRef;
     }
     
+    public function setLabel(text:String) {
+        staticTextRef.setLabel(text);
+    }
+    
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // HELPERS
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////
+    private var staticTextRef(get, null):WxStaticTextRef;
+    private function get_staticTextRef():WxStaticTextRef {
+        return cast _ref;
+    }
 }
 
 @:include("wx/stattext.h")
@@ -40,4 +51,5 @@ extern class WxStaticTextRef extends WxStaticText {
 @:native("wxStaticText")
 extern class WxStaticText extends WxWindow {
     @:native("Create")              public function create(parent:WxWindowRef, id:Int, value:ConstCharStar, point:WxPointRef, size:WxSizeRef, style:Int):Bool;
+    @:native("SetLabel")            public function setLabel(text:ConstCharStar):Void;
 }

--- a/src/hx/widgets/Window.hx
+++ b/src/hx/widgets/Window.hx
@@ -26,10 +26,38 @@ class WindowStyle {
 }
 
 class Window extends EvtHandler {
+
+    private var __children:Array<Window>;
+    private var __parent:Window;
+
     public function new(parent:Window, id:Int) {
         super();
+        
+        if (__children == null)
+            __children = [];
+        
+        if (parent != null)
+        {
+            __parent = parent;
+            __children.push(parent);
+        }
     }
-
+    
+    public function getChildren() {
+        return __children;
+    }
+    
+    public function getParent() {
+        return __parent;
+    }
+    
+    public function getRoot() {
+        if (getParent() != null)
+            return __parent.getRoot();
+        else
+            return this;
+    } 
+    
     public function show(value:Bool) {
         _ref.show(value);
     }
@@ -39,7 +67,13 @@ class Window extends EvtHandler {
     }
     
     public function destroy() {
+        __children = null;
         _ref.destroy();
+    }
+    
+    public function destroyChildren():Bool {
+        __children = [];
+        return _ref.destroyChildren();
     }
     
     public function setSize(x:Int, y:Int, width:Int, height:Int) {
@@ -52,6 +86,19 @@ class Window extends EvtHandler {
     
     public function addChild(child:Window) {
         _ref.addChild(child._ref);
+        __children.push(child);
+    }
+    
+    public function removeChild(child:Window) {
+        _ref.removeChild(child._ref);
+        __children.splice(__children.indexOf(child), 1);
+    }
+    
+    public function findWindowById(id:Int) {
+        var winRef:WxWindowRef = _ref.findWindowById(id);
+        var win:Window = new Window(null, -1);
+        win._ref = cast winRef;
+        return win;
     }
     
     public function refresh() {
@@ -137,6 +184,11 @@ class Window extends EvtHandler {
         _ref.setClientSize(width, height);
     }
     
+    public function getClientSize() {
+        var ref:WxSizeRef = _ref.getClientSize();
+        return new Size(ref.getWidth(), ref.getHeight());
+    }
+    
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     // HELPERS
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -165,11 +217,15 @@ extern class WxWindow extends WxEvtHandler {
     @:native("Show")                    public function show(value:Bool):Void;
     @:native("Close")                   public function close(force:Bool):Bool;
     @:native("Destroy")                 public function destroy():Bool;
+    @:native("DestroyChildren")         public function destroyChildren():Bool;
     @:native("Refresh")                 public function refresh():Void;
     @:native("SetSize")                 public function setSize(x:Int, y:Int, width:Int, height:Int):Void;
     @:native("SetClientSize")           public function setClientSize(width:Int, height:Int):Void;
+    @:native("GetClientSize")           public function getClientSize():WxSizeRef;
     @:native("Move")                    public function move(x:Int, y:Int):Void;
     @:native("AddChild")                public function addChild(child:WxWindowRef):Void;
+    @:native("RemoveChild")             public function removeChild(child:WxWindowRef):Void;
+    @:native("FindWindow")              public function findWindowById(id:Int):WxWindowRef;
     @:native("GetBackgroundColour")     public function getBackgroundColour():Int;
     @:native("SetBackgroundColour")     public function setBackgroundColour(colour:Int):Void;
     @:native("GetWindowStyle")          public function getWindowStyle():Int;
@@ -178,4 +234,20 @@ extern class WxWindow extends WxEvtHandler {
     @:native("GetPosition")             public function getPosition():WxPointRef;
     @:native("SetVirtualSize")          public function setVirtualSize(width:Int, height:Int):Void;
     @:native("GetVirtualSize")          public function getVirtualSize():WxSizeRef;
+}
+
+@:access(hx.widgets.Window)
+class RepositioningGuard {
+    private var _ref:WxChildrenRepositioningGuardRef;
+
+    public function new(win:Window) {
+        _ref = WxChildrenRepositioningGuardRef.createInstance(win._ref);
+    }
+}
+
+@:include("wx/window.h")
+@:unreflective
+@:native("wxWindow::ChildrenRepositioningGuard*")
+extern class WxChildrenRepositioningGuardRef {
+    @:native("new wxWindow::ChildrenRepositioningGuard") public static function createInstance(win:WxWindowRef):WxChildrenRepositioningGuardRef;
 }

--- a/src/hx/widgets/Window.hx
+++ b/src/hx/widgets/Window.hx
@@ -39,7 +39,7 @@ class Window extends EvtHandler {
         if (parent != null)
         {
             __parent = parent;
-            __children.push(parent);
+            __parent.__children.push(this);
         }
     }
     


### PR DESCRIPTION
If you're wondering why there is also a `__children` variable in the `Window` class, is because I didn't want to have to deal with the `wxWindowList` thing just to get the children of a Window.